### PR TITLE
Fix QName display in schema validation message

### DIFF
--- a/xmlschemastypes.c
+++ b/xmlschemastypes.c
@@ -5718,7 +5718,7 @@ xmlSchemaGetCanonValue(xmlSchemaValPtr val, const xmlChar **retValue)
 		*retValue = BAD_CAST xmlStrcat((xmlChar *) (*retValue),
 		    BAD_CAST "}");
 		*retValue = BAD_CAST xmlStrcat((xmlChar *) (*retValue),
-		    BAD_CAST val->value.qname.uri);
+		    BAD_CAST val->value.qname.name);
 	    }
 	    break;
 	case XML_SCHEMAS_DECIMAL:


### PR DESCRIPTION
Errors with QName values were erroneously reported as "{uri}uri" instead
of "{uri}name"
