### PR TITLE
Check "cur" before dereference.

### DIFF
--- a/tree.c
+++ b/tree.c
@@ -5265,7 +5265,7 @@ xmlNodeGetBase(const xmlDoc *doc, const xmlNode *cur) {
         return(NULL);
     if ((cur != NULL) && (cur->type == XML_NAMESPACE_DECL))
         return(NULL);
-    if (doc == NULL) doc = cur->doc;
+    if ((doc == NULL) && (cur != NULL)) doc = cur->doc;
     if ((doc != NULL) && (doc->type == XML_HTML_DOCUMENT_NODE)) {
         cur = doc->children;
 	while ((cur != NULL) && (cur->name != NULL)) {


### PR DESCRIPTION
As cur is checked at other places, it is missed at this location. Added Null check.
