### PR TITLE
The Root element should retain all but empty ns declarations.

### DIFF
--- a/c14n.c
+++ b/c14n.c
@@ -791,6 +791,20 @@ xmlExcC14NProcessNamespacesAxis(xmlC14NCtxPtr ctx, xmlNodePtr cur, int visible)
 	}
     }
 
+    /* For the root node we should keep all ns declarations except the
+     * empty default ns, so explicitly output all declarations */
+    if(cur->parent != NULL && cur->parent->type == XML_DOCUMENT_NODE) {
+        for(ns = cur->nsDef; ns != NULL; ns = ns->next) {
+            if(visible && xmlC14NIsVisible(ctx, ns, cur)) {
+                if(!xmlExcC14NVisibleNsStackFind(ctx->ns_rendered, ns, ctx)) {
+                    xmlListInsert(list, ns);
+                }
+            }
+            if(visible) {
+                xmlC14NVisibleNsStackAdd(ctx->ns_rendered, ns, cur);
+            }
+        }
+    }
 
     /* add attributes */
     for(attr = cur->properties; attr != NULL; attr = attr->next) {


### PR DESCRIPTION
As far as I can see the C14N serialization is not according to specification here. As the output of namespace declarations is done as needed (I.e. the namespace usage on an element triggers the output of the declaration of the namespace) all namespace declarations on the root elements are not preserved as they should be according to the specification.

According to http://www.w3.org/TR/2001/REC-xml-c14n-20010315 :

"The root document element is handled specially since it has no parent
element. All namespace declarations in it are retained, except the
declaration of an empty default namespace is automatically omitted."

Perhaps this is not the optimal way of doing this, feel free to point me in the right direction if this is the case. 

Cheers.
