### PR TITLE
Fix: Wrong function signature for "xmlSchemaAugmentImportedIDC"

### DIFF
--- a/xmlschemas.c
+++ b/xmlschemas.c
@@ -22031,7 +22031,7 @@ xmlSchemaAugmentIDC(xmlSchemaIDCPtr idcDef,
  * Creates an augmented IDC definition for the imported schema.
  */
 static void
-xmlSchemaAugmentImportedIDC(xmlSchemaImportPtr imported, xmlSchemaValidCtxtPtr vctxt) {
+xmlSchemaAugmentImportedIDC(xmlSchemaImportPtr imported, xmlSchemaValidCtxtPtr vctxt, xmlChar *name) {
     if (imported->schema->idcDef != NULL) {
 	    xmlHashScan(imported->schema->idcDef ,
 	    (xmlHashScanner) xmlSchemaAugmentIDC, vctxt);


### PR DESCRIPTION
While compiling and testing with emscripten, I've encountered a problem with an invalid function signature. I've fixed it and just want to share with you.