### PR TITLE
Case insensitive comparison should be used for HTTP header field name…

### DIFF
--- a/HTMLtree.c
+++ b/HTMLtree.c
@@ -127,19 +127,11 @@ found_meta:
     return(NULL);
 
 found_content:
-    encoding = xmlStrstr(content, BAD_CAST"charset=");
-    if (encoding == NULL)
-	encoding = xmlStrstr(content, BAD_CAST"Charset=");
-    if (encoding == NULL)
-	encoding = xmlStrstr(content, BAD_CAST"CHARSET=");
+    encoding = xmlStrcasestr(content, BAD_CAST"charset=");
     if (encoding != NULL) {
 	encoding += 8;
     } else {
-	encoding = xmlStrstr(content, BAD_CAST"charset =");
-	if (encoding == NULL)
-	    encoding = xmlStrstr(content, BAD_CAST"Charset =");
-	if (encoding == NULL)
-	    encoding = xmlStrstr(content, BAD_CAST"CHARSET =");
+	encoding = xmlStrcasestr(content, BAD_CAST"charset =");
 	if (encoding != NULL)
 	    encoding += 9;
     }


### PR DESCRIPTION
…s given in http-equiv

See https://www.w3.org/TR/html401/struct/global.html#adef-http-equiv