### PR TITLE
Add environment CFLAGS to makefile.msvc

### DIFF
--- a/win32/Makefile.msvc
+++ b/win32/Makefile.msvc
@@ -44,7 +44,7 @@ CPPFLAGS = $(CPPFLAGS) /D "_REENTRANT"
 
 # The compiler and its options.
 CC = cl.exe
-CFLAGS = /nologo /D "_WINDOWS" /D "_MBCS" /D "NOLIBTOOL" /W3 /wd4244 /wd4267 $(CRUNTIME)
+CFLAGS = /nologo /D "_WINDOWS" /D "_MBCS" /D "NOLIBTOOL" /W3 /wd4244 /wd4267 $(CRUNTIME) $(CFLAGS)
 CFLAGS = $(CFLAGS) /I$(XML_SRCDIR) /I$(XML_SRCDIR)\include /I$(INCPREFIX)
 !if "$(WITH_THREADS)" != "no"
 CFLAGS = $(CFLAGS) /D "_REENTRANT"


### PR DESCRIPTION
Libxml2 uses its own CFLAGS and does not consider additional flags  like guard:cf and QSpectre that we can easily set in our environment for libxml2 to pick up. As a result, we have to manually rebuild libxml2 by adding the additional flags in Makefile.msvc everytime we want a new flag added. This change will give flexibility to set the needed CFLAGS in the environment itself