### PR TITLE
Declare XMLPUBVAR as extern for clang-cl

### DIFF
--- a/include/libxml/xmlexports.h
+++ b/include/libxml/xmlexports.h
@@ -58,7 +58,7 @@
   #undef XMLCDECL
   #if defined(IN_LIBXML) && !defined(LIBXML_STATIC)
     #define XMLPUBFUN __declspec(dllexport)
-    #define XMLPUBVAR __declspec(dllexport)
+    #define XMLPUBVAR __declspec(dllexport) extern
   #else
     #define XMLPUBFUN
     #if !defined(LIBXML_STATIC)


### PR DESCRIPTION
"The use of dllexport implies a definition, while dllimport implies a declaration. You must use the extern keyword with dllexport to force a declaration; otherwise, a definition is implied." [1]

This code compiles on MSVC. But with clang-cl, it failed because of duplicated symbols.

[1] https://docs.microsoft.com/en-us/cpp/cpp/definitions-and-declarations-cpp