### PR TITLE
Fix building with ICU 68.

### DIFF
--- a/encoding.c
+++ b/encoding.c
@@ -2004,7 +2004,7 @@ xmlEncOutputChunk(xmlCharEncodingHandler *handler, unsigned char *out,
 #ifdef LIBXML_ICU_ENABLED
     else if (handler->uconv_out != NULL) {
         ret = xmlUconvWrapper(handler->uconv_out, 0, out, outlen, in, inlen,
-                              TRUE);
+                              1);
     }
 #endif /* LIBXML_ICU_ENABLED */
     else {


### PR DESCRIPTION
ICU 68 no longer defines the `TRUE` macro, as outlined in their updated [Coding Guidelines](https://github.com/unicode-org/icu/blob/master/docs/userguide/dev/codingguidelines.md#primitive-types).

This causes building libxml2 with ICU 68 to fail with the following error:
```
encoding.c:1961:31: error: use of undeclared identifier ‘TRUE’
               TRUE);
               ^
```

Given that `xmlUconvWrapper()` defines the parameter as `int flush`, using `1` instead of `TRUE` seems like the best solution.