### PR TITLE
Patch to set IO error on file not found

### DIFF
--- a/xmlIO.c
+++ b/xmlIO.c
@@ -860,7 +860,7 @@ xmlFileOpen_real (const char *filename) {
     /* Do not check DDNAME on zOS ! */
 #if !defined(__MVS__)
     if (!xmlCheckFilename(path)){
-        xmlIOErr(0, path);
+    	xmlIOErr(0, path);
         return(NULL);
     }
 #endif

--- a/xmlIO.c
+++ b/xmlIO.c
@@ -859,8 +859,8 @@ xmlFileOpen_real (const char *filename) {
 
     /* Do not check DDNAME on zOS ! */
 #if !defined(__MVS__)
-    if (!xmlCheckFilename(path)){
-    	xmlIOErr(0, path);
+    if (!xmlCheckFilename(path)) {
+        xmlIOErr(0, path);    	
         return(NULL);
     }
 #endif

--- a/xmlIO.c
+++ b/xmlIO.c
@@ -860,7 +860,6 @@ xmlFileOpen_real (const char *filename) {
     /* Do not check DDNAME on zOS ! */
 #if !defined(__MVS__)
     if (!xmlCheckFilename(path)) {
-    	xmlIOErr(0, path);
         return(NULL);
 	}
 #endif

--- a/xmlIO.c
+++ b/xmlIO.c
@@ -860,6 +860,7 @@ xmlFileOpen_real (const char *filename) {
     /* Do not check DDNAME on zOS ! */
 #if !defined(__MVS__)
     if (!xmlCheckFilename(path)) {
+	xmlIOErr(0, path);	    
         return(NULL);
 	}
 #endif

--- a/xmlIO.c
+++ b/xmlIO.c
@@ -859,10 +859,10 @@ xmlFileOpen_real (const char *filename) {
 
     /* Do not check DDNAME on zOS ! */
 #if !defined(__MVS__)
-    if (!xmlCheckFilename(path)) {
-	xmlIOErr(0, path);	    
+    if (!xmlCheckFilename(path)){
+        xmlIOErr(0, path);
         return(NULL);
-	}
+    }
 #endif
 
 #if defined(_WIN32) || defined (__DJGPP__) && !defined (__CYGWIN__)

--- a/xmlIO.c
+++ b/xmlIO.c
@@ -859,8 +859,10 @@ xmlFileOpen_real (const char *filename) {
 
     /* Do not check DDNAME on zOS ! */
 #if !defined(__MVS__)
-    if (!xmlCheckFilename(path))
+    if (!xmlCheckFilename(path)) {
+    	xmlIOErr(0, path);
         return(NULL);
+	}
 #endif
 
 #if defined(_WIN32) || defined (__DJGPP__) && !defined (__CYGWIN__)


### PR DESCRIPTION
Currently whenever a file is not present for reading, NULL is simply returned after calling xmlCheckFilename() without setting any errors, thus not catching any errors in error callbacks. This makes it difficult to understand what caused the file opening to fail. Calling xmlIOErr(0, path) on it's negative scenario, sets the error appropriately so we can handle the file not found scenario effectively.