### PR TITLE
doc: typo in comment in dict.c

### DIFF
--- a/dict.c
+++ b/dict.c
@@ -104,7 +104,7 @@ xmlInitDictInternal(void) {
  * DEPRECATED: This function is a no-op. Call xmlCleanupParser
  * to free global state but see the warnings there. xmlCleanupParser
  * should be only called once at program exit. In most cases, you don't
- * have call cleanup functions at all.
+ * have to call cleanup functions at all.
  */
 void
 xmlDictCleanup(void) {


### PR DESCRIPTION
Just a small typo I saw when reading through the code