### PR TITLE
build: add `Bcrypt` to the dependencies on Windows

### DIFF
--- a/libxml2-config.cmake.cmake.in
+++ b/libxml2-config.cmake.cmake.in
@@ -158,6 +158,7 @@ if(NOT LIBXML2_SHARED)
 
   if(WIN32)
     list(APPEND LIBXML2_LIBRARIES ws2_32)
+    list(APPEND LIBXML2_LIBRARIES Bcrypt)
   endif()
 endif()
 

--- a/libxml2-config.cmake.in
+++ b/libxml2-config.cmake.in
@@ -115,6 +115,8 @@ endif()
 if(WIN32)
   list(APPEND LIBXML2_LIBRARIES    ws2_32)
   list(APPEND LIBXML2_INTERFACE_LINK_LIBRARIES "\$<LINK_ONLY:ws2_32>")
+  list(APPEND LIBXML2_LIBRARIES    Bcrypt)
+  list(APPEND LIBXML2_INTERFACE_LINK_LIBRARIES "\$<LINK_ONLY:Bcrypt>")
 endif()
 
 # whether libxml2 has dso support


### PR DESCRIPTION
The use of `BCryptGenRandom` requires linking against `Bcrypt` on Windows. Add this library to the interface and link libraries set for dependencies so that static linking works properly.