### PR TITLE
don't overwrite possible error from 1st check in case 2nd check is passed

### DIFF
--- a/testparser.c
+++ b/testparser.c
@@ -365,7 +365,8 @@ testHugeEncodedChunk(void) {
 
     xmlParseChunk(ctxt, (char *) chunk, xmlStrlen(chunk), 1);
 
-    err = ctxt->wellFormed ? 0 : 1;
+    if (!ctxt->wellFormed)
+        err = 1;
     xmlFreeDoc(ctxt->myDoc);
     xmlFreeParserCtxt(ctxt);
     xmlFree(chunk);


### PR DESCRIPTION
Commit https://github.com/GNOME/libxml2/commit/3eced32ea3633b6f2077a4a98e08b5ba7a6ecf99 added an additional check to test case `testHugeEncodedChunk()` in testparser.c. But the new check is overwriting the result of the existing check:

```
testHugeEncodedChunk(void) {
    ...
    err = ctxt->wellFormed ? 0 : 1; // existing check
    ...
    err = ctxt->wellFormed ? 0 : 1; // new check
    ...
    return err;
}
```
I changed the 2nd assignment to only overwrite `err`, when the 2nd check failed:
```
    if (!ctxt->wellFormed)
        err = 1;
```
